### PR TITLE
Fix duplicate definiton of :not selector

### DIFF
--- a/special.lisp
+++ b/special.lisp
@@ -129,7 +129,6 @@
 
 (define-single-arg-selector dir)
 (define-single-arg-selector lang)
-(define-single-arg-selector not)
 (define-single-arg-selector nth-child)
 (define-single-arg-selector nth-last-child)
 (define-single-arg-selector nth-last-of-type)


### PR DESCRIPTION
Most CL implementations accept duplicate definitions of methods/functions, but CCL will generate a (proper) compiler warning which may fail the build in some circumstances.